### PR TITLE
Extend the Navigator interface with `scheduling`

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,9 +137,9 @@
       </section>
     </section>
     <section>
-      <h2>Extensions to the <dfn data-cite="HTML5#the-window-object">Window</dfn> interface</h2>
+      <h2>Extensions to the <dfn data-cite="HTML5#the-navigator-object">Navigator</dfn> interface</h2>
       <pre class="idl">
-        partial interface Window {
+        partial interface Navigator {
           readonly attribute Scheduling scheduling;
         };
       </pre>


### PR DESCRIPTION
Changes the IDL to extend the Navigator interface, rather than the
Window interface (putting the spec in line with the examples, WG
discussions, and Blink implementation).

Fixes #30.