### PR TITLE
Leverage the user interaction task source to query tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         wg: "Web Platform Incubator Community Group",
         wgURI: "https://www.w3.org/community/wicg/",
         github: "https://github.com/WICG/is-input-pending",
+        xref: "web-platform",
       };
     </script>
   </head>
@@ -101,16 +102,19 @@
         <h3>The <dfn>isInputPending</dfn> Method</h3>
         <p>The <code>isInputPending</code> method returns a value based on the options set listed in <code>isInputPendingOptions</code>. If the <code>isInputPending</code> method is called then the user agent MUST run the following steps:</p>
         <ol>
-          <li>Let <i>pendingResult</i> be false.</li>
-          <li>If <var>isInputPendingOptions</var> is undefined, assign it to a newly-instantiated <a>IsInputPendingOptions</a> with default parameters.</li>
-          <li>The user agent MAY at this step continue to step 5 for any reason.</li>
-          <li>If the <dfn data-cite="ecmascript#surrounding-agent">surrounding agent</dfn>'s <dfn data-cite="html#event-loop">event loop</dfn> has any <dfn data-cite="html#task-queue">task queues</dfn> that contain a <dfn data-cite="html#concept-task">task</dfn> that will <dfn data-cite="dom#concept-event-dispatch">dispatch</dfn> an event that is a <dfn data-cite="uievents#idl-uievent">UIEvent</dfn> or <dfn data-cite="touch-events#touchevent-interface">TouchEvent</dfn> or a child of either, or if the user agent determines that it might soon enqueue such a task, and the dispatched event would have an EventTarget that exists within a window of the same origin, then the user agent MUST run the following steps:<ol type="a">
-            <li>If the user agent considers the task to be a <a>continuous event task</a> and <i>isInputPendingOptions.includeContinuous</i> is false, continue to step 5.</li>
-            <li>The user agent MAY let <i>pendingResult</i> be true.</li>
-          </ol></li>
-          <li>Return <i>pendingResult</i>.</li>
+          <li>Let |pendingResult : boolean| be false.</li>
+          <li>If |isInputPendingOptions : IsInputPendingOptions| is undefined, assign it to a newly-instantiated <a>IsInputPendingOptions</a> with default parameters.</li>
+          <li>Let |queue : task queue| be the <dfn data-cite="html#task-queue">task queue</dfn> to which the [= user interaction task source =] is associated on the <dfn data-cite="ecmascript#surrounding-agent">surrounding agent</dfn>'s <dfn data-cite="html#event-loop">event loop</dfn>.</li>
+          <li>
+            For each |task : task| on |queue|:
+            <ol>
+              <li>If the user agent considers |task| to be a [= continuous event task =] and {{IsInputPendingOptions/includeContinuous}} is false in |isInputPendingOptions|, continue.</li>
+              <li>If the user agent predicts that |task| will [= dispatch =] an [= event =] to an <dfn data-cite="html#eventtarget">EventTarget</dfn> in a cross-origin window, continue.</li>
+              <li>The user agent MAY set |pendingResult| to true.</li>
+            </ol>
+          </li>
+          <li>Return |pendingResult|.</li>
         </ol>
-        <p>Any task used in step 3 SHOULD have been queued after <code>isInputPendingOptions</code> was instantiated.</p>
         <p class="note">The overall goal for this api is to allow user agents to return true if they think an event may end up getting dispatched to a unit of same origin <dfn data-cite="html#browsing-context">browsing context</dfn> soon, and not only if an event is already placed into the queue. This may mean that a user agent may look into the current configuration of iframes, other events in the queue, or other information when making decisions in step 2.1. For example, there may be cases where if a mousedown event is dispatched then a click event may be fired for this frame after the mousedown event. However if the mousedown event is canceled then the user agent knows that the click event will not be fired. In this case the user agent should return 'true' for a 'click' input before the canceling mousedown event, but after it knows that a click will not be fired it should return false.</p>
 
         <p class="note">The specification for the isInputPending method is intentionally written in such a way that a user agent may return false for any reason. This is so user agents may include their own security and performance measures while implementing this api and remain compliant with this specification. For example, some user agents may not know which unit of same origin browsing context they would dispatch an event to without a prohibitively expensive computation, in that case it would be okay for the user agent to return false. It's never okay for a user agent to return true when it's unsure that the unit of same origin browsing context querying isInputPending is not the same one where the event will be dispatched. Returning true for an event that may get dispatched to a different origin browsing context could allow for parent iframes to observe events in different origin child iframes, which would be a violation of security.</p>
@@ -129,7 +133,7 @@
       <p class="note">The distinction between <a>continuous events</a> and other event types exists in order to prevent script from yielding too often. Under normal circumstances, a user moving their pointer around on a document wouldn’t expect that to have any effect on performance so by default these events are excluded from <a data-link-for="Scheduling">isInputPending</a>. However, there may be times when a document wants to yield for these events.</p>
       <section>
         <h3>Continuous event</h3>
-        <p>An event MUST be considered a <dfn>continuous event</dfn> if it is a <dfn data-cite="dom#dom-event-istrusted">trusted event</dfn> of type <dfn data-cite="uievents#event-type-mousemove">mousemove</dfn>, <dfn data-cite="uievents#event-type-wheel">wheel</dfn>, <dfn data-cite="touch-events#the-touchmove-event">touchmove</dfn>, <dfn data-cite="html#dragevent">drag</dfn>, <dfn data-cite="pointerevents3#the-pointermove-event">pointermove</dfn>, or <dfn data-cite="pointerevents3#the-pointerrawupdate-event">pointerrawupdate</dfn> or a child of any of those. A user agent MAY consider other trusted events that are of a specific type and are children of <a>UIEvent</a> or <a>TouchEvent</a> to be a <a>continuous event</a> as long as those specific types are consistent for that user agent and that all events of those types or children of those types are considered <a>continuous events</a>.</p>
+        <p>An event MUST be considered a <dfn>continuous event</dfn> if it is a <dfn data-cite="dom#dom-event-istrusted">trusted event</dfn> of type <dfn data-cite="uievents#event-type-mousemove">mousemove</dfn>, <dfn data-cite="uievents#event-type-wheel">wheel</dfn>, <dfn data-cite="touch-events#the-touchmove-event">touchmove</dfn>, <dfn data-cite="html#dragevent">drag</dfn>, <dfn data-cite="pointerevents3#the-pointermove-event">pointermove</dfn>, or <dfn data-cite="pointerevents3#the-pointerrawupdate-event">pointerrawupdate</dfn> or a child of any of those. A user agent MAY consider other trusted events that are of a specific type and are children of <dfn data-cite="uievents#idl-uievent">UIEvent</dfn> or <dfn data-cite="touch-events#touchevent-interface">TouchEvent</dfn> to be a <a>continuous event</a> as long as those specific types are consistent for that user agent and that all events of those types or children of those types are considered <a>continuous events</a>.</p>
         <p class="note">All of event types that are considered to be <a>continuous events</a> are specified in such a way where they are fired successively, and the user agent is encouraged to fire the events at a rate specific for the user agent and platform. The language about a user agent being able to include other event types is there so user agents that have nonstandard events that are defined in a similar manner may also be considered to be <a>continuous events</a>.</p>
       </section>
       <section>


### PR DESCRIPTION
Cleans up the processing model by relying on tasks dispatched using the
user interaction task source, and reading from the associated task
queue.

Fixes #43.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/acomminos/should-yield/pull/45.html" title="Last updated on Aug 2, 2021, 7:07 PM UTC (960a4a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/is-input-pending/45/86e0dd6...acomminos:960a4a8.html" title="Last updated on Aug 2, 2021, 7:07 PM UTC (960a4a8)">Diff</a>